### PR TITLE
Allow predict method to return utility values

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -190,7 +190,7 @@ idx_name.mlogit <- function(x, n = NULL, m = NULL){
 
 #' @rdname miscmethods.mlogit
 #' @export
-predict.mlogit <- function(object, newdata = NULL, returnData = FALSE, ...){
+predict.mlogit <- function(object, newdata = NULL, type = "probabilities", returnData = FALSE, ...){
     # if no newdata is provided, use the mean of the model.frame
     if (is.null(newdata)){
         newdata <- mean(object$model)
@@ -244,10 +244,13 @@ predict.mlogit <- function(object, newdata = NULL, returnData = FALSE, ...){
     # update the model and get the probabilities
     newobject <- update(object, start = coef(object, fixed = TRUE), data = newdata, iterlim = 0, print.level = 0)
 #    newobject <- update(object, start = coef(object), data = newdata, iterlim = 0, print.level = 0)
-    result <- newobject$probabilities
-    if (nrow(result) == 1){
-        result <- as.numeric(result)
-        names(result) <- colnames(object$probabilities)
+    
+    result <- fitted(newobject, type)
+    if(type == "probabilities"){
+        if (nrow(result) == 1){
+            result <- as.numeric(result)
+            names(result) <- colnames(object$probabilities)
+        }
     }
     if (returnData) attr(result, "data") <- newdata
     result

--- a/man/miscmethods.mlogit.Rd
+++ b/man/miscmethods.mlogit.Rd
@@ -54,7 +54,13 @@ model.response.mlogit(object, ...)
 
 \method{idx_name}{mlogit}(x, n = NULL, m = NULL)
 
-\method{predict}{mlogit}(object, newdata = NULL, returnData = FALSE, ...)
+\method{predict}{mlogit}(
+  object,
+  newdata = NULL,
+  type = "probabilities",
+  returnData = FALSE,
+  ...
+)
 
 \method{fitted}{mlogit}(
   object,


### PR DESCRIPTION
As far as I could tell, the existing `predict.mlogit` method only returned the predicted probabilities. The `fitted.mlogit` method could return multiple types of response, but could not use the `newdata` argument. This commit:

  - Exposes the "type" argument from the fitted method as an argument to predict, with default set to "probabilities" (the current behavior)
  - Replaces the call to `newobject$probabilities` with a call to the more flexible `fitted` method.